### PR TITLE
Bumped version and standardized property names

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,18 @@ A Python Module to interact with the Mitre ATT&CK Framework
 * All techniques have suggested mitigations as a property
 * For each class you can access additional information about related data points:
 
-* Actor
+* Actors
   * Tools used by the Actor or Group
   * Malware used by the Actor or Group
   * Techniques this Actor or Group uses
-* Malware
+* Malwares
   * Actor or Group(s) using this malware
   * Techniques this malware is used with
-* Mitigation
+* Mitigations
   * Techniques related to a specific set of mitigation suggestions
-* Tactic
+* Tactics
   * Techniques found in a specific Tactic (phase)
-* Technique
+* Techniques
   * Tactics a technique is found in
   * Mitigation suggestions for a given technique
   * Actor or Group(s) identified as using this technique
@@ -85,7 +85,7 @@ for actor in attack.actors:
     print(actor)
     
     # accessing malware used by an actor or group
-    for malware in actor.malware:
+    for malware in actor.malwares:
         print(malware)
 
     # accessing tools used by an actor or group
@@ -110,7 +110,7 @@ for malware in attack.malwares:
 
 # accessing mitigation
 for mitigation in attack.mitigations:
-    print(mit)
+    print(mitigation)
 
     # accessing techniques related to mitigation recommendations
     for technique in mitigation.techniques:
@@ -133,7 +133,7 @@ for technique in attack.techniques:
         print(tactic)
 
     # accessing mitigation recommendations for this technique
-    for mitigation in technique.mitigation:
+    for mitigation in technique.mitigations:
         print(mitigation)
 
     # accessing actors using this technique
@@ -161,6 +161,10 @@ for tool in attack.tools:
    * Initial release of pyattck to PyPi
 * 1.0.1
    * Updating Documentation with new reference links
+* 1.0.2
+   * Updated Documentation
+* 1.0.3
+   * Fixed issue with appending techniques correctly
 
 ## Meta
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -148,7 +148,7 @@ Below shows you how you can access each of object types and their properties.  A
        print(actor)
     
        # accessing malware used by an actor or group
-       for malware in actor.malware:
+       for malware in actor.malwares:
            print(malware)
 
        # accessing tools used by an actor or group
@@ -173,7 +173,7 @@ Below shows you how you can access each of object types and their properties.  A
 
    # accessing mitigation
    for mitigation in attack.mitigations:
-       print(mit)
+       print(mitigation)
 
        # accessing techniques related to mitigation recommendations
        for technique in mitigation.techniques:
@@ -196,7 +196,7 @@ Below shows you how you can access each of object types and their properties.  A
            print(tactic)
 
        # accessing mitigation recommendations for this technique
-       for mitigation in technique.mitigation:
+       for mitigation in technique.mitigations:
            print(mitigation)
 
        # accessing actors using this technique

--- a/pyattck/actor.py
+++ b/pyattck/actor.py
@@ -29,7 +29,7 @@ class AttckActor(AttckObject):
         self.contributor = super(AttckActor, self)._set_list_items(kwargs, 'x_mitre_contributors')
 
     @property
-    def malware(self):
+    def malwares(self):
         '''Returns all malware objects as a list that are documented as being used by an Actor or Group
         '''
         from .malware import AttckMalware

--- a/pyattck/technique.py
+++ b/pyattck/technique.py
@@ -50,7 +50,7 @@ class AttckTechnique(AttckObject):
             if 'x-mitre-tactic' in item['type']:
                 for tact in self._tactic:
                     if str(tact).lower() == str(item['x_mitre_shortname']).lower():
-                    tactic_list.append(AttckTactic(**item))
+                        tactic_list.append(AttckTactic(**item))
         return tactic_list
             
 
@@ -76,7 +76,7 @@ class AttckTechnique(AttckObject):
         
 
     @property
-    def mitigation(self):
+    def mitigations(self):
         '''Returns all mitigation objects as a list that are documented to help mitigate the current technique object'''
         from .mitigation import AttckMitigation
         mitigation_list = []

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def parse_requirements(requirement_file):
 
 setup(
     name='pyattck',
-    version='1.0.2',
+    version='1.0.3',
     packages=find_packages(exclude=['tests*']),
     license='MIT',
     description='A Python package to interact with the Mitre ATT&CK Framework',


### PR DESCRIPTION
Standardized property names to be pluralized across all classes.  Anything that returns a list, then the property name will have a 's' (e.g. malwares, techniques, actors, etc.).  Bumped minor version to 1.0.3