### PR TITLE
Adding MITRE PRE-ATT&CK Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,15 @@
     | _|          |__| /__/     \__\  |__|        |__|      \______||__|\__\
 
 ```
-	A Python package to interact with the MITRE ATT&CK Framework
+	A Python package to interact with MITRE ATT&CK Frameworks
 
 
-**pyattck** is a light-weight framework for the MITRE ATT&CK Framework. This package extracts details about MITRE ATT&CK Tactics, Techniques, Actors/Groups, Tools, Malware, and Mitigations provided by MITRE.
+**pyattck** is a light-weight framework for MITRE ATT&CK Frameworks. This package extracts details from the MITRE ATT&CK Enterprise & PRE-ATT&CK Frameworks.
 
 ## Features
 
-The **pyattck** package retrieves all Tactics, Techniques, Actors, Malware, Tools, and Mitigations from the MITRE ATT&CK Enterprise framework as well as any defined relationships within the MITRE ATT&CK dataset. In addition, Techniques, Actors, and Tools (if applicable) now have collected data from third-party resources that are accessible via properties on a technique. For more detailed information about these features, see [External Datasets](docs/dataset/dataset.md).
+The **pyattck** package retrieves all Tactics, Techniques, Actors, Malware, Tools, and Mitigations from the MITRE ATT&CK Frameworks as well as any defined relationships within the MITRE ATT&CK dataset.
+In addition, Techniques, Actors, and Tools (if applicable) now have collected data from third-party resources that are accessible via properties on a technique. For more detailed information about these features, see [External Datasets](docs/dataset/dataset.md).
 
 The **pyattck** package allows you to:
 
@@ -26,6 +27,7 @@ The **pyattck** package allows you to:
   * Specify a local file path for the MITRE ATT&CK Enterprise Framework json, generated dataset, and/or a config.yml file.
   * Retrieve an image_logo of an actor (when available). If an image_logo isn't available, it generates an ascii_logo.
   * Search the external dataset for external commands that are similar using `search_commands`.
+  * Access data from the MITRE PRE-ATT&CK Framework
 
 ## Installation
 
@@ -78,6 +80,7 @@ Once you have a `Attck` object, you can access the MITRE ATT&CK Enterprise frame
 You can access the following `main` properties on your **Attck** object:
 
 * enterprise
+* preattack
 
 Once you specify the MITRE ATT&CK Framework, you can access additional properties.
 
@@ -91,6 +94,15 @@ Here are the accessible objects under the [Enterprise](docs/enterprise/enterpris
 * [tools](docs/enterprise/tools.md)
 
 For more information on object types under the `enterprise` property, see [Enterprise](docs/enterprise/enterprise.md).
+
+Here are the accessible objects under the [PreAttck](docs/preattck/preattck.md) property:
+
+* [actors](docs/preattck/actor.md)
+* [tactics](docs/preattck/tactic.md)
+* [techniques](docs/preattck/technique.md)
+
+
+For more information on object types under the `preattck` property, see [PreAttck](docs/preattck/preattck.md).
 
 ## Note
 
@@ -182,4 +194,5 @@ This data set is generated from many different sources. As we continue to add mo
    pyattck/attck
    dataset/dataset
    enterprise/enterprise
+   preattck/preattck
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,14 +11,15 @@
     | _|          |__| /__/     \__\  |__|        |__|      \______||__|\__\
 
 ```
-	A Python package to interact with the MITRE ATT&CK Framework
+	A Python package to interact with MITRE ATT&CK Frameworks
 
 
-**pyattck** is a light-weight framework for the MITRE ATT&CK Framework. This package extracts details about MITRE ATT&CK Tactics, Techniques, Actors/Groups, Tools, Malware, and Mitigations provided by MITRE.
+**pyattck** is a light-weight framework for MITRE ATT&CK Frameworks. This package extracts details from the MITRE ATT&CK Enterprise & PRE-ATT&CK Frameworks.
 
 ## Features
 
-The **pyattck** package retrieves all Tactics, Techniques, Actors, Malware, Tools, and Mitigations from the MITRE ATT&CK Enterprise framework as well as any defined relationships within the MITRE ATT&CK dataset. In addition, Techniques, Actors, and Tools (if applicable) now have collected data from third-party resources that are accessible via properties on a technique. For more detailed information about these features, see [External Datasets](dataset/dataset.md).
+The **pyattck** package retrieves all Tactics, Techniques, Actors, Malware, Tools, and Mitigations from the MITRE ATT&CK Frameworks as well as any defined relationships within the MITRE ATT&CK dataset.
+In addition, Techniques, Actors, and Tools (if applicable) now have collected data from third-party resources that are accessible via properties on a technique. For more detailed information about these features, see [External Datasets](dataset/dataset.md).
 
 The **pyattck** package allows you to:
 
@@ -26,6 +27,7 @@ The **pyattck** package allows you to:
   * Specify a local file path for the MITRE ATT&CK Enterprise Framework json, generated dataset, and/or a config.yml file.
   * Retrieve an image_logo of an actor (when available). If an image_logo isn't available, it generates an ascii_logo.
   * Search the external dataset for external commands that are similar using `search_commands`.
+  * Access data from the MITRE PRE-ATT&CK Framework
 
 ## Installation
 
@@ -78,6 +80,7 @@ Once you have a `Attck` object, you can access the MITRE ATT&CK Enterprise frame
 You can access the following `main` properties on your **Attck** object:
 
 * enterprise
+* preattack
 
 Once you specify the MITRE ATT&CK Framework, you can access additional properties.
 
@@ -91,6 +94,15 @@ Here are the accessible objects under the [Enterprise](enterprise/enterprise.md)
 * [tools](enterprise/tools.md)
 
 For more information on object types under the `enterprise` property, see [Enterprise](enterprise/enterprise.md).
+
+Here are the accessible objects under the [PreAttck](docs/preattck/preattck.md) property:
+
+* [actors](docs/preattck/actor.md)
+* [tactics](docs/preattck/tactic.md)
+* [techniques](docs/preattck/technique.md)
+
+
+For more information on object types under the `preattck` property, see [PreAttck](docs/preattck/preattck.md).
 
 ## Note
 
@@ -182,4 +194,5 @@ This data set is generated from many different sources. As we continue to add mo
    pyattck/attck
    dataset/dataset
    enterprise/enterprise
+   preattck/preattck
 ```

--- a/docs/preattck/actor.md
+++ b/docs/preattck/actor.md
@@ -1,0 +1,35 @@
+# PreAttckActor
+
+This documentation provides details about PreAttckActor class within the `pyattck` package.
+
+The `PreAttckActor` class provides detailed information about identified actors & groups within the MITRE PRE-ATT&CK Framework.  Additionally, an `PreAttckActor` object allows the user to access additional relationships within the MITRE PRE-ATT&CK Framework:
+
+* Techniques this Actor or Group uses
+
+You can also access external data properties. The following properties are generated using external data:
+
+* country
+* operations
+* attribution_links
+* known_tools
+* targets
+* additional_comments
+* external_description
+
+You can retrieve the entire dataset using the `external_dataset` property.
+
+An additional fun feature is that you can now retrieve a logo for a actor.  Currently, a limited set of logos are provided.
+If a logo is not provided, then `pyattck` will generate one using ascii art.
+
+You can access these logos using the following properties:
+
+* ascii_logo
+
+## PreAttckActor Class
+
+```eval_rst
+.. autoclass:: pyattck.preattck.actor.PreAttckActor
+   :members:
+   :undoc-members:
+   :show-inheritance:
+```

--- a/docs/preattck/preattck.md
+++ b/docs/preattck/preattck.md
@@ -1,0 +1,110 @@
+# PreAttck
+
+This documentation provides details about the PreAttck class within the `pyattck` package.
+
+The PreAttck class provides detailed information about data within the MITRE PRE-ATT&CK framework
+
+Each of the `main` properties (above) can return a json object of the entire object or you can access each property individually.  An example of this is here:
+
+```python
+from pyattck import Attck
+
+attack = Attck()
+
+# accessing techniques and their properties
+for technique in attack.preattack.techniques:
+	# if you want to return individual properties of this object you call them directly
+	print(technique.id)
+	print(technique.name)
+	print(technique.alias)
+	print(technique.description)
+	print(technique.stix)
+	print(technique.platforms)
+	print(technique.permissions)
+	print(technique.wiki)
+	.....
+```
+
+The following is only a small sample of the available properties on each object and each object type (actors, tactics, and techniques) will have different properties that you can access.
+
+
+* Every data point has exposed properties that allow the user to retrieve additional data based on relationships:
+    * [Actor](preattack/actor.md)
+        * Relationship Objects
+            * Techniques this Actor or Group uses
+        * External Data
+            * Retrieve a logo for an actor using either image_logo or ascii_logo properties
+            * country which this actor or group may be associated with (attribution is hard)
+            * operations 
+            * attribution_links
+            * known_tools
+            * targets
+            * additional_comments
+            * external_description
+    * [Tactic](preattack/tactic.md)
+        * Techniques found in a specific Tactic (phase)
+    * [Technique](preattack/technique.md)
+        * Relationship Objects
+            * Tactics a technique is found in
+            * Actor or Group(s) identified as using this technique
+
+
+Below shows you how you can access each of object types and their properties.  Additionally, you can access related object types associated with this selected object type:
+
+```python
+from pyattck import Attck
+
+attack = Attck()
+
+for actor in attack.preattack.actors:
+    print(actor.id)
+    print(actor.name)
+
+    # accessing techniques used by an actor or group
+    for technique in actor.techniques:
+        print(technique.id)
+        print(technique.name)
+
+# accessing tactics
+for tactic in attack.preattack.tactics:
+    print(tactic.id)
+    print(tactic.name)
+
+    # accessing techniques related to this tactic
+    for technique in tactic.techniques:
+        print(technique.id)
+        print(technique.name)
+
+# accessing techniques
+for technique in attack.preattack.techniques:
+    print(technique.id)
+    print(technique.name)
+
+    # accessing tactics that this technique belongs to
+    for tactic in technique.tactics:
+        print(tactic.id)
+        print(tactic.name)
+
+    # accessing actors using this technique
+    for actor in technique.actors:
+        print(actor.id)
+        print(actor.name)
+```
+
+## PreAttck Class
+
+```eval_rst
+.. autoclass:: pyattck.preattack.preattack.PreAttck
+   :members:
+   :undoc-members:
+   :show-inheritance:
+```
+
+
+```eval_rst
+.. toctree::
+   
+   actor
+   tactic
+   technique
+```

--- a/docs/preattck/tactic.md
+++ b/docs/preattck/tactic.md
@@ -1,0 +1,16 @@
+# PreAttckTactic
+
+This documentation provides details about the `PreAttckTactic` class within the `pyattck` package.
+
+This class provides information about the tactics (columns) within the MITRE PRE-ATT&CK Framework.  Additionally, a `PreAttckTactic` object allows the user to access additional relationships within the MITRE PRE-ATT&CK Framework:
+
+* Techniques found in a specific Tactic (phase)
+
+## PreAttckTactic Class
+
+```eval_rst
+.. autoclass:: pyattck.preattack.preattack.PreAttckTactic
+   :members:
+   :undoc-members:
+   :show-inheritance:
+```

--- a/docs/preattck/technique.md
+++ b/docs/preattck/technique.md
@@ -1,0 +1,17 @@
+# PreAttckTechnique
+
+This documentation provides details about the `PreAttckTechnique` class within the `pyattck` package.
+
+This class provides information about the techniques found under each tactic (columns) within the MITRE PRE-ATT&CK Framework.  Additionally, a `PreAttckTechnique` object allows the user to access additional relationships within the MITRE PRE-ATT&CK Framework:
+
+* Tactics a technique is found in
+* Actor or Group(s) identified as using this technique
+
+## PreAttckTechnique Class
+
+```eval_rst
+.. autoclass:: pyattck.preattack.preattack.PreAttckTechnique
+   :members:
+   :undoc-members:
+   :show-inheritance:
+```

--- a/docs/pyattck/attck.md
+++ b/docs/pyattck/attck.md
@@ -5,6 +5,7 @@ This documentation provides details about the main entry point called `Attck` wi
 This class provides access to the Enterprise MITRE ATT&CK Framework data as well as additional ATT&CK frameworks in the future.
 
 * Enterprise MITRE ATT&CK Framework
+* MITRE PRE-ATT&CK Framework
 
 ## Attck Class
 

--- a/docs/pyattck/configuration.md
+++ b/docs/pyattck/configuration.md
@@ -7,7 +7,7 @@ This documentation provides details about configuration options within the `pyat
 
 You can also specify an alternate location of different file objects.
 
-You can specify the path of an `attck_json` as well as `dataset_json` when instantiating a `Attck` object.
+You can specify the path of an `attck_json` as well as `preattck_json` and `dataset_json` when instantiating a `Attck` object.
 
 Additionally, you can specify the location of a configuration file using `config_path` which must be a yaml file.
 
@@ -18,7 +18,7 @@ Storing and loading datasets from an alternate location
 ```python
 from pyattck import Attck
 
-attack = Attck(attck_json='/Users/{profile_name}/Desktop/attck_json.json', dataset_json='/Users/{profile_name}/Desktop/dataset_json.json')
+attack = Attck(attck_json='/Users/{profile_name}/Desktop/attck_json.json', preattck_json='/Users/{profile_name}/Desktop/preattack.json', dataset_json='/Users/{profile_name}/Desktop/dataset_json.json')
 ```
 
 Specifying an alternate location for a config.yml file:

--- a/pyattck/attck.py
+++ b/pyattck/attck.py
@@ -7,18 +7,20 @@ from .datasets import AttckDatasets
 class Attck(object):
 
     '''
-        This class creates an interface to all Mitre ATT&CK frameworks.
+        This class creates an interface to all MITRE ATT&CK frameworks.
 
         Currently, this class only enables access to the Enterprise framework with others coming soon.
 
         This interface enables you to retrieve all properties within each item in the Mitre ATT&CK Enterprise Framework.
 
+        This interface enables you to retrieve all properties within each item in the MITRE ATT&CK Enterprise Framework.
+
         The following categorical items can be accessed using this class:
 
-            1. Tactics (Tactics are the phases defined by Mitre ATT&CK)
+            1. Tactics (Tactics are the phases defined by MITRE ATT&CK)
             2. Techniques (Techniques are the individual actions which can accomplish a tactic)
             3. Mitigations (Mitigations are recommendations to prevent or protect against a technique)
-            4. Actors (Actors or Groups are identified malicious actors/groups which have been identified and documented by Mitre & third-parties)
+            4. Actors (Actors or Groups are identified malicious actors/groups which have been identified and documented by MITRE & third-parties)
             5. Tools (Tools are software used to perform techniques)
             6. Malwares (Malwares are specific pieces of malware used by actors (or in general) to accomplish a technique)
 
@@ -116,7 +118,7 @@ class Attck(object):
         attck_json (json) - The attck_json is supplied by the attck.py module when instantiated.
 
     Returns:
-        [Attck]: Returns a Attck object that contains all data from the Mitre ATT&CK Framework
+        [Attck]: Returns a Attck object that contains all data from MITRE ATT&CK Frameworks
     '''
 
     __ENTERPRISE_ATTCK_JSON = None
@@ -181,7 +183,7 @@ class Attck(object):
         warnings.warn(
             '''Accessing actors property from an Attck object will be depreciated in version 3.
             
-            Please begin migrating to accessing the Enterprise Mitre ATT&CK objects using the enterprise property''',
+            Please begin migrating to accessing the Enterprise MITRE ATT&CK objects using the enterprise property''',
             DeprecationWarning)
         from .enterprise.actor import AttckActor
         if self.__actors is None:
@@ -203,7 +205,7 @@ class Attck(object):
         warnings.warn(
             '''Accessing tactics property from an Attck object will be depreciated in version 3.
             
-            Please begin migrating to accessing the Enterprise Mitre ATT&CK objects using the enterprise property''',
+            Please begin migrating to accessing the Enterprise MITRE ATT&CK objects using the enterprise property''',
             DeprecationWarning)
         from .enterprise.tactic import AttckTactic
         if self.__tactics is None:
@@ -225,7 +227,7 @@ class Attck(object):
         warnings.warn(
             '''Accessing mitigations property from an Attck object will be depreciated in version 3.
             
-            Please begin migrating to accessing the Enterprise Mitre ATT&CK objects using the enterprise property''',
+            Please begin migrating to accessing the Enterprise MITRE ATT&CK objects using the enterprise property''',
             DeprecationWarning)
         from .enterprise.mitigation import AttckMitigation
         if self.__mitigations is None:
@@ -247,7 +249,7 @@ class Attck(object):
         warnings.warn(
             '''Accessing tools property from an Attck object will be depreciated in version 3.
             
-            Please begin migrating to accessing the Enterprise Mitre ATT&CK objects using the enterprise property''',
+            Please begin migrating to accessing the Enterprise MITRE ATT&CK objects using the enterprise property''',
             DeprecationWarning)
         from .enterprise.tools import AttckTools
         if self.__tools is None:
@@ -269,7 +271,7 @@ class Attck(object):
         warnings.warn(
             '''Accessing malwares property from an Attck object will be depreciated in version 3.
             
-            Please begin migrating to accessing the Enterprise Mitre ATT&CK objects using the enterprise property''',
+            Please begin migrating to accessing the Enterprise MITRE ATT&CK objects using the enterprise property''',
             DeprecationWarning)
         from .enterprise.malware import AttckMalware
         if self.__malwares is None:
@@ -291,7 +293,7 @@ class Attck(object):
         warnings.warn(
             '''Accessing techniques property from an Attck object will be depreciated in version 3.
             
-            Please begin migrating to accessing the Enterprise Mitre ATT&CK objects using the enterprise property''',
+            Please begin migrating to accessing the Enterprise MITRE ATT&CK objects using the enterprise property''',
             DeprecationWarning)
         from .enterprise.technique import AttckTechnique
         if self.__techniques is None:

--- a/pyattck/attck.py
+++ b/pyattck/attck.py
@@ -9,9 +9,10 @@ class Attck(object):
     '''
         This class creates an interface to all MITRE ATT&CK frameworks.
 
-        Currently, this class only enables access to the Enterprise framework with others coming soon.
+        Currently, this class enables access to the Enterprise & PRE-ATT&CK frameworks with others coming soon.  To acccess each framework, use the following properties
 
-        This interface enables you to retrieve all properties within each item in the Mitre ATT&CK Enterprise Framework.
+            * enterprise
+            * preattack
 
         This interface enables you to retrieve all properties within each item in the MITRE ATT&CK Enterprise Framework.
 
@@ -115,7 +116,10 @@ class Attck(object):
                        # etc.
 
     Arguments:
-        attck_json (json) - The attck_json is supplied by the attck.py module when instantiated.
+        attck_json (json) - The attck_json is supplied by the attck.py module when instantiated but can be used to specify an alternate location of your Enterprise ATT&CK json file.  Default is None.
+        dataset_json (json) - The dataset_json is supplied by the attck.py module when instantiated but can be used to specify an alternate location of your dataset json file.  Default is None.
+        preattck_json (json) - The attck_json is supplied by the attck.py module when instantiated but can be used to specify an alternate location of your PRE-ATT&CK json file.  Default is None.
+        config_path (str) - The path to a specified configuration file.  Default is None which equates to ~/pyattck folder directory.
 
     Returns:
         [Attck]: Returns a Attck object that contains all data from MITRE ATT&CK Frameworks
@@ -136,21 +140,27 @@ class Attck(object):
     def __init__(self, attck_json=None, dataset_json=None, preattck_json=None, config_path=None):
         """The main entry point for pyattck.
 
-        When instantiating an Attck object you can currently access the Enterprise Mitre ATT&CK Framework.
+        When instantiating an Attck object you can access either the Enterprise or PRE-ATT&CK MITRE Frameworks.  Specify one of the following properties to access the frameworks specific data:
+
+            * enterprise
+            * preattack
 
         You can specify an alternate location of a local copy of the following objects:
 
-            1. attck_json = Path to the Mitre ATT&CK Enterprise Framework json
-            2. dataset_json = Path to a local dataset json file which is generated in the pyattck repo
+            1. attck_json = Path to the MITRE ATT&CK Enterprise Framework JSON
+            2. dataset_json = Path to a local dataset JSON file which is generated in the pyattck repo
+            3. preattck_json = Path to the the MITRE PRE-ATT&CK Framework JSON
             3. config_path = Path to a yaml configuration file which contains two key value pairs
                 Example content:
 
                     enterprise_attck_dataset: /Users/first.last/pyattck/enterprise_attck_dataset.json
+                    preattck_json: /Users/first.last/pyattck/preattck.json
                     enterprise_attck_json: /Users/first.last/pyattck/enterprise_attck.json
         
         Args:
-            attck_json (str, optional): Path to the Mitre ATT&CK Enterprise Framework json. Defaults to None.
+            attck_json (str, optional): Path to the MITRE ATT&CK Enterprise Framework json. Defaults to None.
             dataset_json (str, optional): Path to a local dataset json file which is generated in the pyattck repo. Defaults to None.
+            preattck_json (str, optional): Path to the MITRE PRE-ATT&CK Framework json. Defaults to None.
             config_path (str, optional): Path to a yaml configuration file which contains two key value pairs. Defaults to None.
         """
 

--- a/pyattck/attck.py
+++ b/pyattck/attck.py
@@ -333,7 +333,7 @@ class Attck(object):
         if preattack:
             self.__load_data(type='preattack', force=True)
         else:
-        self.__load_data(force=True)
+            self.__load_data(force=True)
 
 
     def __load_data(self, type='enterprise', force=False):
@@ -341,7 +341,7 @@ class Attck(object):
             if not Attck.__PRE_ATTCK_JSON:
                 Attck.__PRE_ATTCK_JSON = self.__datasets.mitre(type='preattack', force=force)
         else:
-        if not Attck.__ENTERPRISE_ATTCK_JSON:
-            Attck.__ENTERPRISE_ATTCK_JSON = self.__datasets.mitre(force=force)
-        if not Attck.__ENTERPRISE_GENERATED_DATA_JSON:
-            Attck.__ENTERPRISE_GENERATED_DATA_JSON = self.__datasets.generated_attck_data(force=force)
+            if not Attck.__ENTERPRISE_ATTCK_JSON:
+                Attck.__ENTERPRISE_ATTCK_JSON = self.__datasets.mitre(force=force)
+            if not Attck.__ENTERPRISE_GENERATED_DATA_JSON:
+                Attck.__ENTERPRISE_GENERATED_DATA_JSON = self.__datasets.generated_attck_data(force=force)

--- a/pyattck/configuration.py
+++ b/pyattck/configuration.py
@@ -16,6 +16,7 @@ class Configuration(object):
     
     def __init__(self):
         self.enterprise_attck_json_path = None
+        self.preatack_json_path = None
         self.enterprise_attck_dataset_path = None
 
     def get(self):
@@ -36,35 +37,44 @@ class Configuration(object):
             self.set()
             return self.get()
 
-    def set(self, enterprise_attck_json_path=None, enterprise_attck_dataset_path=None):
+    def set(self, enterprise_attck_json_path=None, preattck_json_path=None, enterprise_attck_dataset_path=None):
         """This method will set pyattcks configuration file settings.
 
         If no config.yml is found, it will generate one with default settings
         
         Args:
             enterprise_attck_json_path (str, optional): Path to store the Enterprise MITRE ATT&CK JSON data file. Defaults to None.
+            preattck_json_path (str, optional): Path to store the MITRE PRE-ATT&CK JSON data file. Defaults to None.
             enterprise_attck_dataset_path (str, optional): Path to store the Enterprise MITRE ATT&CK Generated JSON data file. Defaults to None.
         """        
         config = {}
-        if enterprise_attck_json_path or enterprise_attck_dataset_path:
-            if enterprise_attck_json_path:
-                if '.json' not in enterprise_attck_json_path:
-                    config['enterprise_attck_json'] = '{}/enterprise_attck.json'.format(self.__get_absolute_path(enterprise_attck_json_path))
-                else:
-                    config['enterprise_attck_json'] = self.__get_absolute_path(enterprise_attck_json_path)
+        if enterprise_attck_json_path:
+            if '.json' not in enterprise_attck_json_path:
+                config['enterprise_attck_json'] = '{}/enterprise_attck.json'.format(self.__get_absolute_path(enterprise_attck_json_path))
             else:
-                config['enterprise_attck_json'] = os.path.join(os.path.expanduser('~'), 'pyattck', 'enterprise_attck' + '.json')
-            if enterprise_attck_dataset_path:
-                if '.json' not in enterprise_attck_dataset_path:
-                    config['enterprise_attck_dataset'] = '{}/enterprise_attck_dataset.json'.format(self.__get_absolute_path(enterprise_attck_dataset_path))
-                else:
-                    config['enterprise_attck_dataset'] = self.__get_absolute_path(enterprise_attck_dataset_path)
-            else:
-                config['enterprise_attck_dataset'] = os.path.join(os.path.expanduser('~'), 'pyattck', 'enterprise_attck_dataset' + '.json')
+                config['enterprise_attck_json'] = self.__get_absolute_path(enterprise_attck_json_path)
         else:
             config['enterprise_attck_json'] = os.path.join(os.path.expanduser('~'), 'pyattck', 'enterprise_attck' + '.json')
+
+        
+        if preattck_json_path:
+            if '.json' not in preattck_json_path:
+                config['preattck_json'] = '{}/preattack.json'.format(self.__get_absolute_path(preattck_json_path))
+            else:
+                config['preattck_json'] = self.__get_absolute_path(preattck_json_path)
+        else:
+            config['preattck_json'] = os.path.join(os.path.expanduser('~'), 'pyattck', 'preattck' + '.json')
+        
+
+        if enterprise_attck_dataset_path:
+            if '.json' not in enterprise_attck_dataset_path:
+                config['enterprise_attck_dataset'] = '{}/enterprise_attck_dataset.json'.format(self.__get_absolute_path(enterprise_attck_dataset_path))
+            else:
+                config['enterprise_attck_dataset'] = self.__get_absolute_path(enterprise_attck_dataset_path)
+        else:
             config['enterprise_attck_dataset'] = os.path.join(os.path.expanduser('~'), 'pyattck', 'enterprise_attck_dataset' + '.json')
-            
+
+    
         self.__write_config(config)
 
     def __get_absolute_path(self, value):

--- a/pyattck/datasets.py
+++ b/pyattck/datasets.py
@@ -8,39 +8,56 @@ class AttckDatasets(object):
 
         Default locations to download datasets are as follows:
             MITRE_ATTCK_JSON_URL = 'https://raw.githubusercontent.com/mitre/cti/master/enterprise-attack/enterprise-attack.json'
+            MITRE_PREATTCK_ATTCK_JSON_URL  = 'https://raw.githubusercontent.com/mitre/cti/master/pre-attack/pre-attack.json'
             DATASETS_URL = 'https://raw.githubusercontent.com/swimlane/pyattck/master/generated_attck_data.json'
     """    
 
-    __MITRE_ATTCK_JSON_URL = 'https://raw.githubusercontent.com/mitre/cti/master/enterprise-attack/enterprise-attack.json'
+    __MITRE_ENTERPRISE_ATTCK_JSON_URL = 'https://raw.githubusercontent.com/mitre/cti/master/enterprise-attack/enterprise-attack.json'
+    __MITRE_PREATTCK_ATTCK_JSON_URL  = 'https://raw.githubusercontent.com/mitre/cti/master/pre-attack/pre-attack.json'
     __DATASETS_URL = 'https://raw.githubusercontent.com/swimlane/pyattck/master/generated_attck_data.json'
 
     def __init__(self):
         config = Configuration().get()
         self.attck_json_path = config['enterprise_attck_json']
+        self.preattck_json_path = config['preattck_json']
         self.dataset_json_path = config['enterprise_attck_dataset']
 
-    def mitre(self, force=False):
+
+    def __get_mitre_json(self, url, path, force=False):
+        if force:
+            mitre = requests.get(url).json()
+            self.__save_locally(path, mitre)
+            return mitre
+        else:
+            cached_data = self.__get_cached_data(path)
+            if cached_data:
+                return cached_data
+            else:
+                mitre = requests.get(url).json()
+                self.__save_locally(path, mitre)
+                return mitre
+
+    def mitre(self, type='enterprise', force=False):
         """Downloads, saves, or retrieves the Mitre ATT&CK Enterprise JSON
         
         Args:
+            type (str, optional): Will set the type of data to download/retrieve.  Defaults to Enterprise.  Options are enterprise, preattack
             force (bool, optional): Will force the download of a new JSON file. Defaults to False.
         
         Returns:
             [dict]: Mitre ATT&CK Enterprise Framework JSON
         """        
         # first check to see if it already exists
-        if force:
-            mitre = requests.get(self.__MITRE_ATTCK_JSON_URL).json()
-            self.__save_locally(self.attck_json_path, mitre)
-            return mitre
+        if type == 'enterprise':
+            url = self.__MITRE_ENTERPRISE_ATTCK_JSON_URL
+            return self.__get_mitre_json(url, self.attck_json_path, force=force)
+        elif type == 'preattack':
+            url = self.__MITRE_PREATTCK_ATTCK_JSON_URL
+            return self.__get_mitre_json(url, self.preattck_json_path, force=force)
         else:
-            cached_data = self.__get_cached_data(self.attck_json_path)
-            if cached_data:
-                return cached_data
-            else:
-                mitre = requests.get(self.__MITRE_ATTCK_JSON_URL).json()
-                self.__save_locally(self.attck_json_path, mitre)
-                return mitre
+            url = self.__MITRE_ENTERPRISE_ATTCK_JSON_URL
+            return self.__get_mitre_json(url, self.attck_json_path, force=force)
+
 
     def generated_attck_data(self, force=False):
         """Downloads, saves, or retrieves the Mitre ATT&CK Enterprise Generated Dataset JSON

--- a/pyattck/preattck/__init__.py
+++ b/pyattck/preattck/__init__.py
@@ -1,0 +1,1 @@
+from .preattck import PreAttck

--- a/pyattck/preattck/actor.py
+++ b/pyattck/preattck/actor.py
@@ -1,0 +1,213 @@
+from .preattckobject import PreAttckObject
+from ..utils.logo import Logo
+from ..utils.exceptions import GeneratedDatasetException
+from ..datasets import AttckDatasets
+
+
+class PreAttckActor(PreAttckObject):
+
+    '''A child class of PreAttckObject
+    
+    Creates objects that are categorized as MITRE PRE-ATT&CK Actors or Groups (e.g. APT1, APT32, etc.)
+
+    You can also access external data properties. The following properties are generated using external data:
+
+        1. country
+        2. operations
+        3. attribution_links
+        4. known_tools
+        5. targets
+        6. additional_comments
+        7. external_description
+
+    You can retrieve the entire dataset using the `external_dataset` property.
+
+    pyattck also enables you to retrieve or generate logos for the actor or group using the following properties:
+        
+        - ascii_logo - Generated ASCII logo based on the actor or groups name
+    
+    Example:
+        You can iterate over an `actors` list and access specific properties and relationship properties.
+
+        The following relationship properties are accessible:
+                
+                1. techniques
+        
+            1. To iterate over an `actors` list, do the following:
+
+            .. code-block:: python
+               
+               from pyattck import Attck
+
+               attck = Attck()
+
+               for actor in attck.preattack.actors:
+                   print(actor.id)
+                   print(actor.name)
+                   print(actor.aliases)
+                   print(actor.description)
+                   # etc.
+
+            2. To access relationship properties, do the following:
+
+            .. code-block:: python
+
+               from pyattck import Attck
+
+               attck = Attck()
+
+               for actor in attck.preattack.actors:
+                   print(actor.id)
+                   print(actor.name)
+                   print(actor.aliases)
+                   print(actor.description)
+
+                   for technique in actor.techniques:
+                       print(technique.name)
+                       print(technique.description)
+                       # etc.
+    '''
+
+    __PREATTCK_DATASETS = None
+
+    def __init__(self, preattck_obj = None, **kwargs):
+        """Creates objects that are categorized as MITRE PRE-ATT&CK Actors or Groups (e.g. APT1, APT32, etc.)
+
+        Arguments:
+            attck_obj (json) -- Takes the raw MITRE PRE-ATT&CK Json object
+            AttckObject (dict) -- Takes the MITRE PRE-ATT&CK Json object as a kwargs values
+
+        Raises:
+            GeneratedDatasetException: Error when accessing third-party generated datasets
+        """
+        super(PreAttckActor, self).__init__(**kwargs)
+        self.preattck_obj = preattck_obj
+
+        self.created_by_ref = self._set_attribute(kwargs, 'created_by_ref')
+        self.version = self._set_attribute(kwargs, 'x_mitre_version')
+        self.name = self._set_attribute(kwargs, 'name')
+        self.aliases = self._set_list_items(kwargs, 'aliases')
+        self.external_reference = self._set_reference(kwargs)
+        self.stix = self._set_attribute(kwargs, 'id')
+        self.contributor = self._set_list_items(kwargs, 'x_mitre_contributors')
+
+        self.set_relationships(self.preattck_obj)
+
+        logo = Logo(self.name.strip().replace(' ','_').lower())
+        self.ascii_logo = logo.get_ascii()
+        
+        if PreAttckActor.__PREATTCK_DATASETS is None:
+            try:
+                data = AttckDatasets().generated_attck_data()
+                if 'actors' in data:
+                    PreAttckActor.__PREATTCK_DATASETS = data['actors']
+            except:
+                raise GeneratedDatasetException('Unable to retrieve generated attack data properties')
+            
+        self.external_dataset = self.__get_actors_dataset()
+        
+
+    def __get_actors_dataset(self):
+        return_list = []
+        self.country = []
+        self.operations = []
+        self.attribution_links = []
+        self.known_tools = []
+        self.targets = []
+        self.additional_comments = []
+        self.external_description = []
+        for country in PreAttckActor.__PREATTCK_DATASETS:
+            if country:
+                for k,v in country.items():
+                    for actor in v['actors']:
+                        if 'names' in actor:
+                            if actor['names']:
+                                if self.name in actor['names']:
+                                    if k not in self.country:
+                                        self.country.append(k)
+                                    return_list.append(actor)
+                                    if 'operations' in actor:
+                                        if actor['operations']:
+                                            for operation in actor['operations']:
+                                                if operation not in self.operations:
+                                                    self.operations.append(operation)
+                                    if 'links' in actor:
+                                        if actor['links']:
+                                            for link in actor['links']:
+                                                if link not in self.attribution_links:
+                                                    self.attribution_links.append(link)
+                                    if 'tools' in actor:
+                                        if actor['tools']:
+                                            for tool in actor['tools']:
+                                                if tool not in self.known_tools:
+                                                    self.known_tools.append(tool)
+                                    if 'targets' in actor:
+                                        if actor['targets']:
+                                            if actor['targets'] not in self.targets:
+                                                self.targets.append(actor['targets'])
+                                    if 'comment' in actor:
+                                        if actor['comment']:
+                                            if actor['comment'] not in self.additional_comments:
+                                                self.additional_comments.append(actor['comment'])
+                                    if 'description' in actor:
+                                        if actor['description']:
+                                            if actor['description'] not in self.external_description:
+                                                self.external_description.append(actor['description'])
+                            if self.aliases:
+                                for alias in self.aliases:
+                                    if alias in actor['names']:
+                                        if k not in self.country:
+                                            self.country.append(k)
+                                        return_list.append(actor)
+                                        if 'operations' in actor:
+                                            if actor['operations']:
+                                                for operation in actor['operations']:
+                                                    if operation not in self.operations:
+                                                        self.operations.append(operation)
+                                        if 'links' in actor:
+                                            if actor['links']:
+                                                for link in actor['links']:
+                                                    if link not in self.attribution_links:
+                                                        self.attribution_links.append(link)
+                                        if 'tools' in actor:
+                                            if actor['tools']:
+                                                for tool in actor['tools']:
+                                                    if tool not in self.known_tools:
+                                                        self.known_tools.append(tool)
+                                        if 'targets' in actor:
+                                            if actor['targets']:
+                                                if actor['targets'] not in self.targets:
+                                                    self.targets.append(actor['targets'])
+                                        if 'comment' in actor:
+                                            if actor['comment']:
+                                                if actor['comment'] not in self.additional_comments:
+                                                    self.additional_comments.append(actor['comment'])
+                                        if 'description' in actor:
+                                            if actor['description']:
+                                                if actor['description'] not in self.external_description:
+                                                    self.external_description.append(actor['description'])
+        if return_list:
+            return return_list
+        else:
+            return None
+
+
+    @property
+    def techniques(self):
+        """Accessing an actors known techniques as part of the MITRE PRE-ATT&CK Framework
+
+        Returns:
+            list: Returns all technique objects as a list that are documented as being used by an Actor or Group
+        """
+        from .technique import PreAttckTechnique
+        return_list = []
+        item_dict = {}
+        for item in self.preattck_obj['objects']:
+            if 'type' in item:
+                if item['type'] == 'attack-pattern':
+                    item_dict[item['id']] = item
+        
+        for item in self._RELATIONSHIPS[self.stix]:
+            if item in item_dict:
+                return_list.append(PreAttckTechnique(**item_dict[item]))
+        return return_list

--- a/pyattck/preattck/preattck.py
+++ b/pyattck/preattck/preattck.py
@@ -1,0 +1,146 @@
+from .technique import PreAttckTechnique
+from .actor import PreAttckActor
+from .tactic import PreAttckTactic
+
+
+class PreAttck(object):
+
+    '''
+        This class creates an interface to all data points in the MITRE PRE-ATT&CK framework.
+
+        This interface enables you to retrieve all properties within each item in the MITRE PRE-ATT&CK Framework.
+
+        The following categorical items can be accessed using this class:
+
+            1. Tactics (Tactics are the phases defined by MITRE ATT&CK)
+            2. Techniques (Techniques are the individual actions which can accomplish a tactic)
+            3. Actors (Actors or Groups are identified malicious actors/groups which have been identified and documented by MITRE & third-parties)
+
+        Each Actor object (if available) enables you to access the following properties on the object:
+
+            1. country
+            2. operations
+            3. attribution_links
+            4. known_tools
+            5. targets
+            6. additional_comments
+            7. external_description
+
+        You can retrieve the entire dataset using the `external_dataset` property on a `actor` object.
+
+        pyattck also enables you to retrieve or generate logos for the actor or group using the following properties:
+        
+            - ascii_logo - Generated ASCII logo based on the actor or groups name
+
+    
+    Example:
+        Once an Attck object is instantiated, you can access each object type as a list of objects (e.g. techniques, tactics, actors, etc.)
+
+        You can iterate over each object list and access specific properties and relationship properties of each.
+        
+        The following relationship properties are accessible:
+            1. Actors
+                1. Techniques this Actor or Group uses
+            2. Tactics
+                1. Techniques found in a specific Tactic (phase)
+            3. Techniques
+                1. Tactics a technique is found in
+                2. Actor or Group(s) identified as using this technique
+        
+            1. To iterate over a list, do the following:
+
+            .. code-block:: python
+               
+               from pyattck import Attck
+
+               attck = Attck()
+               
+               for technique in attck.preattack.techniques:
+                   print(technique.id)
+                   print(technique.name)
+                   print(technique.description)
+                   # etc.
+               
+
+            2. To access relationship properties, do the following:
+
+            .. code-block:: python
+
+               from pyattck import Attck
+
+               attck = Attck()
+               
+               for technique in attck.preattack.techniques:
+                   print(technique.id)
+                   print(technique.name)
+                   print(technique.description)
+                   # etc.
+
+                   for actor in technique.actors:
+                       print(actor.id)
+                       print(actor.name)
+                       print(actor.description)
+                       # etc.
+    '''
+    
+    __tactics = None
+    __techniques = None
+    __mitigations = None
+    __actors = None
+    __tools = None
+    __malwares = None
+    
+    def __init__(self, preattck_json):
+        """
+        Sets standard properties that are found in all child classes as well as provides standard methods used by inherited classes
+        
+        Arguments:
+            preattck_json (json) - The preattck_json is supplied by the attck.py module when instantiated.
+
+        Returns:
+            [PreAttck]: Returns a PreAttck object that contains all data from the MITRE PRE-ATT&CK Framework
+        """
+        self.preattck = preattck_json
+
+    @property
+    def actors(self):
+        """Access all actors within the MITRE PRE-ATT&CK Framework
+        
+        Returns:
+            PreAttckActor: Returns a list of PreAttckActor objects
+        """
+        if self.__actors is None:
+            self.__actors = []
+            for group in self.preattck['objects']:
+                if group['type'] == 'intrusion-set':
+                    self.__actors.append(PreAttckActor(preattck_obj=self.preattck, **group))
+        return self.__actors
+
+    @property
+    def tactics(self):
+        """Access all tactics within the MITRE PRE-ATT&CK Framework
+        
+        Returns:
+            PreAttckTactic: Returns a list of PreAttckTactic objects
+        """
+        if self.__tactics is None:
+            self.__tactics = []
+            for tactic in self.preattck['objects']:
+                if tactic['type'] == 'x-mitre-tactic':
+                    self.__tactics.append(PreAttckTactic(preattck_obj=self.preattck, **tactic))
+        return self.__tactics
+
+
+    @property
+    def techniques(self):
+        """Access all techniques within the MITRE PRE-ATT&CK Framework
+                
+        Returns:
+            PreAttckTechnique: Returns a list of PreAttckTechnique objects
+        """
+        if self.__techniques is None:
+            self.__techniques = []
+            for technique in self.preattck["objects"]:
+                if (technique['type'] == 'attack-pattern'):
+                    self.__techniques.append(PreAttckTechnique(preattck_obj=self.preattck, **technique))
+        return self.__techniques

--- a/pyattck/preattck/preattckobject.py
+++ b/pyattck/preattck/preattckobject.py
@@ -1,0 +1,158 @@
+import json 
+from collections import OrderedDict
+
+def jsonDefault(OrderedDict):
+    return OrderedDict.__dict__
+
+class PreAttckObject(object):
+    '''
+        Parent class of all other MITRE PRE-ATT&CK based classes
+
+        This is a private class and should not be accessed directly
+    '''
+
+    _RELATIONSHIPS = None
+    
+    def __init__(self, **kwargs):
+        """
+        Sets standard properties that are found in all child classes as well as provides standard methods used by inherited classes
+        
+        Arguments:
+            kwargs (dict) -- Takes the MITRE PRE-ATT&CK Json object as a kwargs values
+        """
+        self.id = self._set_id(kwargs)
+        self.name = self._set_attribute(kwargs, 'name')
+        self.description = self._set_attribute(kwargs, 'description')
+        self.reference = self._set_reference(kwargs)
+        self.created = self._set_attribute(kwargs, 'created')
+        self.modified = self._set_attribute(kwargs, 'modified')
+        self.type = self._set_attribute(kwargs, 'type')
+        
+
+    def __str__(self):
+        return json.dumps(self, default=jsonDefault, indent=4)
+
+    def set_relationships(self, attck_obj):
+        if not PreAttckObject._RELATIONSHIPS:
+            relationship_obj = {}
+            for item in attck_obj['objects']:
+                if 'type' in item:
+                    if item['type'] == 'relationship':
+                        source_id = item['source_ref']
+                        target_id = item['target_ref']
+                        if source_id not in relationship_obj:
+                            relationship_obj[source_id] = []
+                        relationship_obj[source_id].append(target_id)
+
+                        if target_id not in relationship_obj:
+                            relationship_obj[target_id] = []
+                        relationship_obj[target_id].append(source_id)
+            PreAttckObject._RELATIONSHIPS = relationship_obj
+
+    def set_relationship(self, obj, id, name):
+        """Sets relationships on two objects based on a defined relationship from MITRE PRE-ATT&CK
+        
+        Args:
+            obj (dict): MITRE PRE-ATT&CK Json object
+            id (str): A MITRE PRE-ATT&CK source reference ID
+            name (str): A MITRE PRE-ATT&CK object type
+        
+        Returns:
+            list: A list of related MITRE PRE-ATT&CK related objects based on provided inputs
+        """        
+        return_list = []
+        for item in obj['objects']:
+            if 'source_ref' in item:
+                if id in item['source_ref']:
+                    for o in obj['objects']:
+                        if o['type'] == name:
+                            if item['target_ref'] in o['id']:
+                                return_list.append(o)
+        return return_list
+
+    def _set_attribute(self, obj, name):
+        """Parent class method to set attribute based on passed in object
+           and the name of the property
+        
+        Arguments:
+            obj (dict) -- Provided json objects are passed to this method
+            name (str) -- The json property name to set attribute in child classes
+        
+        Returns:
+            (str) -- Returns either the value of the attribute requested or returns 'null'
+        """
+        try:
+            value = obj.get(name)
+            return None if not value else value
+        except:
+            return None
+
+
+    def _set_list_items(self, obj, list_name):
+        """Private method used by child classes and normalizes list items
+        
+        Args:
+            obj (dict) -- Provided json objects are passed to this method
+            list_name (str) -- The json property name to set list items attribute in child classes
+        
+        Returns:
+            list: returns a list of values from the provided list_name property
+        """        
+        item_value = []
+        if list_name in obj:
+            for item in obj[list_name]:
+                item_value.append(item)
+                
+            return item_value
+
+    def _set_id(self, obj):
+        """Returns the MITRE PRE-ATT&CK Framework external ID 
+        
+        Arguments:
+            obj (dict) -- A MITRE PRE-ATT&CK Framework json object
+        
+        Returns:
+            (str) -- Returns the MITRE PRE-ATT&CK Framework external ID
+        """
+        if "external_references" in obj:
+            for p in obj['external_references']:
+                for s in p:
+                    if p[s] == 'mitre-attack':
+                        return p['external_id']
+        return 'S0000'
+        
+    def _set_wiki(self, obj):
+        """Returns the MITRE ATT&CK Framework Wiki URL
+        
+        Arguments:
+            obj (dict) -- A MITRE PRE-ATT&CK Framework json object
+        
+        Returns:
+            (str) -- Returns the MITRE PRE-ATT&CK Framework Wiki URL
+        """
+        if "external_references" in obj:
+            for p in obj['external_references']:
+                for s in p:
+                    if p[s] == 'mitre-attack':
+                        return p['url']
+
+
+    def _set_reference(self, obj):
+        """Returns a list of external references from the provided MITRE PRE-ATT&CK Framework json object
+        
+        Arguments:
+            obj (dict) -- A MITRE PRE-ATT&CK Framework json object
+        
+        Returns:
+            (dict) -- Returns a dict containing the following key/value pairs
+                external_id (str) -- The MITRE PRE-ATT&CK Framework external ID
+                url (str)         -- The MITRE PRE-ATT&CK Framework URL
+                source_name (str) -- The MITRE PRE-ATT&CK Framework source name
+                description (str) -- The MITRE PRE-ATT&CK Framework description or None if it does not exist
+        """
+        return_list = []
+        if "external_references" in obj:
+            for p in obj['external_references']:
+                return_list.append(p)
+        return return_list
+               

--- a/pyattck/preattck/tactic.py
+++ b/pyattck/preattck/tactic.py
@@ -1,0 +1,80 @@
+from .preattckobject import PreAttckObject
+
+class PreAttckTactic(PreAttckObject):
+    
+    def __init__(self, preattck_obj = None, **kwargs):
+        '''A child class of PreAttckObject
+    
+        Creates objects that are categorized as MITRE PRE-ATT&CK Tactics
+    
+        Example:
+        
+            You can iterate over an `tactics` list and access specific properties and relationship properties.
+
+            The following relationship properties are accessible:
+                    1. techniques
+        
+            1. To iterate over an `tactics` list, do the following:
+
+            .. code-block:: python
+               
+               from pyattck import Attck
+
+               attck = Attck()
+
+               for tactic in attck.preattack.tactics:
+                   print(tactic.id)
+                   print(tactic.name)
+                   print(tactic.aliases)
+                   print(tactic.description)
+                   # etc.
+
+            2. To access relationship properties, do the following:
+
+            .. code-block:: python
+
+               from pyattck import Attck
+
+               attck = Attck()
+
+               for tactic in attck.preattack.tactics:
+                   print(tactic.id)
+                   print(tactic.name)
+                   print(tactic.aliases)
+                   print(tactic.description)
+                   # etc.
+
+                   for technique in tactic.techniques:
+                       print(technique.name)
+                       print(technique.description)
+                       # etc.
+
+        Arguments:
+            attck_obj (json) -- Takes the raw MITRE PRE-ATT&CK Json object
+            AttckObject (dict) -- Takes the MITRE PRE-ATT&CK Json object as a kwargs values
+        '''
+        super(PreAttckTactic, self).__init__(**kwargs)
+        self.preattck_obj = preattck_obj
+
+        self.created_by_ref = self._set_attribute(kwargs, 'created_by_ref')
+        self.stix = self._set_attribute(kwargs, 'id')
+        self.short_name = self._set_attribute(kwargs, 'x_mitre_shortname')
+        
+
+        self.set_relationships(self.preattck_obj)
+
+    @property
+    def techniques(self):
+        """Accessing techniques a specific tactic belongs to based on the MITRE PRE-ATT&CK Framework
+
+        Returns:
+            list: Returns all technique objects within the defined tactic
+        """
+        from .technique import PreAttckTechnique
+        technique_list = []
+        for item in self.preattck_obj['objects']:
+            if 'kill_chain_phases' in item:
+                for prop in item['kill_chain_phases']:
+                    if str(prop['phase_name']).lower() == str(self.short_name).lower():
+                        technique_list.append(PreAttckTechnique(**item))
+        return technique_list

--- a/pyattck/preattck/technique.py
+++ b/pyattck/preattck/technique.py
@@ -1,0 +1,147 @@
+from .preattckobject import PreAttckObject
+
+class PreAttckTechnique(PreAttckObject):
+    '''A child class of AttckObject
+    
+    Creates objects which have been categorized as a technique used by attackers
+    
+    Each technique enables you to access the following properties on the object:
+
+        1. command_list - A list of commands associated with a technique
+        2. commands = A list of dictionary objects containing source, command, and provided name associated with a technique
+        3. queries = A list of dictionary objects containing product, query, and name associated with a technique
+        4. datasets = A list of raw datasets associated with a technique
+        5. possible_detections = A list of raw datasets containing possible detection methods for a technique
+
+
+    Example:
+        You can iterate over an `techniques` list and access specific properties and relationship properties.
+
+        The following relationship properties are accessible:
+                1. tactics
+                2. mitigations
+                3. actors
+        
+            1. To iterate over an `techniques` list, do the following:
+
+            .. code-block:: python
+               
+               from pyattck import Attck
+
+               attck = Attck()
+
+               for technique in attck.techniques:
+                   print(technique.id)
+                   print(technique.name)
+                   print(technique.aliases)
+                   print(technique.description)
+                   # etc.
+
+            2. To access relationship properties, do the following:
+
+            .. code-block:: python
+
+               from pyattck import Attck
+
+               attck = Attck()
+
+               for technique in attck.techniques:
+                   print(technique.id)
+                   print(technique.name)
+                   print(technique.aliases)
+                   print(technique.description)
+                   # etc.
+
+                   for malware in technique.malwares:
+                       print(malware.name)
+                       print(malware.description)
+                       # etc.
+
+    Arguments:
+        attck_obj (json) -- Takes the raw Mitre ATT&CK Json object
+        AttckObject (dict) -- Takes the Mitre ATT&CK Json object as a kwargs values
+    '''
+
+    __LOCAL_FOLDER_PATH = None
+
+    def __init__(self, preattck_obj = None, **kwargs):
+        """Creates an PreAttckTechnique object.  
+           The PreAttckTechnique object is a technique used by attackers.
+        """
+        super(PreAttckTechnique, self).__init__(**kwargs)
+        self.preattck_obj = preattck_obj
+
+        self.old_attack_id = self._set_attribute(kwargs, 'x_mitre_old_attack_id')
+        self.common_defenses = self._set_attribute(kwargs, 'x_mitre_detectable_by_common_defenses_explanation')
+        self.tactics = kwargs
+        self.version = self._set_attribute(kwargs, 'x_mitre_version')
+        self.difficult = self._set_attribute(kwargs, 'x_mitre_difficulty_for_adversary')
+        self.difficulty_reason = self._set_attribute(kwargs, 'x_mitre_difficulty_for_adversary_explanation')
+        self.created_by_reference = self._set_attribute(kwargs, 'created_by_ref')
+        self.detectable = self._set_attribute(kwargs, 'x_mitre_detectable_by_common_defenses')
+        self.possible_detections = self._set_attribute(kwargs, 'x_mitre_detectable_by_common_defenses_explanation')
+        self.deprecated = self._set_attribute(kwargs, 'x_mitre_deprecated')
+        self.stix = self._set_attribute(kwargs, 'id')
+
+        self.set_relationships(self.preattck_obj)
+
+    @property
+    def tactics(self):
+        """Accessing tactics a specific technique belongs to based on the MITRE PRE-ATT&CK Framework
+
+        Returns:
+            list: Returns all tactic objects as a techinque belongs to
+        """
+        from .tactic import PreAttckTactic
+        tactic_list = []
+        for item in self.preattck_obj['objects']:
+            if 'x-mitre-tactic' in item['type']:
+                for tact in self._tactic:
+                    if str(tact).lower() == str(item['x_mitre_shortname']).lower():
+                        tactic_list.append(PreAttckTactic(**item))
+        return tactic_list
+            
+
+    @tactics.setter
+    def tactics(self, obj):
+        """Sets the associated tactic/phase this technique is in
+        
+        Arguments:
+            obj (dict) -- A MITRE PRE-ATT&CK Framework json object
+        
+        Returns:
+            (string) -- Returns a string that sets the tactic/phase this technique is in. 
+                        If there is no phase found, it will return 'no phase_name'
+        """
+
+        temp_list = []
+        try:
+            for phase in obj['kill_chain_phases']:
+                temp_list.append(phase['phase_name'])
+            self._tactic = temp_list
+        except:
+            self._tactic = ['no phase_name']
+        
+
+
+    @property
+    def actors(self):
+        """Accessing actors who are known to use a specific technique as part of the MITRE PRE-ATT&CK Framework
+
+        Returns:
+            list: Returns all actor objects as a list that are documented as using a technique
+        """
+        from .actor import PreAttckActor
+        return_list = []
+        item_dict = {}
+        for item in self.preattck_obj['objects']:
+            if 'type' in item:
+                if item['type'] == 'intrusion-set':
+                    item_dict[item['id']] = item
+        try:
+            for item in self._RELATIONSHIPS[self.stix]:
+                if item in item_dict:
+                    return_list.append(PreAttckActor(**item_dict[item]))
+        except:
+            pass
+        return return_list

--- a/tests/preattck/test_preattck.py
+++ b/tests/preattck/test_preattck.py
@@ -1,0 +1,36 @@
+import pytest
+import os
+import yaml
+from os.path import expanduser
+
+
+@pytest.mark.parametrize(
+    'target_attribute', 
+    ['techniques', 'tactics', 'actors']
+)
+def test_preattck_attck_attribute_is_list(target_attribute):
+    from pyattck import Attck
+    path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'fixtures', 'generated_attck_data' + '.json')
+    attck = Attck()
+    preattack = getattr(attck, 'preattack')
+    assert isinstance(
+        getattr(preattack, target_attribute),
+        list
+    )
+
+@pytest.mark.parametrize(
+    'target_attribute', 
+    ['techniques', 'tactics', 'actors']
+)
+@pytest.mark.parametrize(
+    'target_properties',
+    ['id','name','description','created','modified','stix','type']
+)
+
+def test_all_preattck_attck_objects_have_standard_properties(target_attribute,target_properties):
+    from pyattck import Attck
+    path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'fixtures', 'generated_attck_data' + '.json')
+    attck = Attck()
+    preattack = getattr(attck, 'preattack')
+    for attribute in getattr(preattack,target_attribute):
+        assert getattr(attribute,target_properties)

--- a/tests/preattck/test_preattck_actors.py
+++ b/tests/preattck/test_preattck_actors.py
@@ -1,0 +1,72 @@
+
+def test_preattck_actors_have_techniques(attck_fixture):
+    """All Mitre PRE-ATT&CK Techniques should have techniques
+    
+    Args:
+        attck_fixture ([type]): our default Mitre PRE-ATT&CK JSON fixture
+    """
+    for actor in attck_fixture.preattack.actors:
+        if actor.techniques:
+            assert getattr(actor,'techniques')
+
+
+def test_some_preattck_actors_have_generated_datasets(attck_fixture):
+    """All Mitre PRE-ATT&CK Techniques should have techniques
+    
+    Args:
+        attck_fixture ([type]): our default Mitre PRE-ATT&CK JSON fixture
+    """
+    count = 0
+    for actor in attck_fixture.preattack.actors:
+        if hasattr(actor, 'external_dataset'):
+            count += 1
+    if count >= 1:
+        assert True
+
+def test_some_preattck_actors_have_generated_datasets_properties(attck_fixture):
+    """All Mitre PRE-ATT&CK Techniques should have techniques
+    
+    Args:
+        attck_fixture ([type]): our default Mitre PRE-ATT&CK JSON fixture
+    """
+    country_count = 0
+    operations_count = 0
+    attribution_links_count = 0
+    known_tools_count = 0
+    targets_count = 0
+    additional_comments_count = 0
+    external_description_count = 0
+    for actor in attck_fixture.preattack.actors:
+        if hasattr(actor, 'country'):
+            country_count += 1
+        if hasattr(actor, 'operations'):
+            operations_count += 1
+        if hasattr(actor, 'attribution_links'):
+            attribution_links_count += 1
+        if hasattr(actor, 'known_tools'):
+            known_tools_count += 1
+        if hasattr(actor, 'targets'):
+            targets_count += 1
+        if hasattr(actor, 'additional_comments'):
+            additional_comments_count += 1
+        if hasattr(actor, 'external_description'):
+            external_description_count += 1
+
+    if country_count >= 1 and operations_count >= 1 and attribution_links_count >= 1 and known_tools_count >= 1 and targets_count >= 1 and additional_comments_count >= 1 and external_description_count >= 1:
+        assert True
+   
+def test_preattck_actors_has_ascii_logo(attck_fixture):
+    """All Mitre PRE-ATT&CK Techniques should have techniques
+    
+    Args:
+        attck_fixture ([type]): our default Mitre PRE-ATT&CK JSON fixture
+    """
+    count = 0
+    logo_count = 0
+    for actor in attck_fixture.preattack.actors:
+        count += 1
+        if hasattr(actor, 'ascii_logo'):
+            logo_count += 1
+        
+    if count == logo_count:
+        assert True

--- a/tests/preattck/test_preattck_tactics.py
+++ b/tests/preattck/test_preattck_tactics.py
@@ -1,0 +1,9 @@
+
+def test_preattck_tactics_have_techniques(attck_fixture):
+    """All Mitre PRE-ATT&CK Techniques should have tactics
+    
+    Args:
+        attck_fixture ([type]): our default Mitre PRE-ATT&CK JSON fixture
+    """
+    for tactic in attck_fixture.preattack.tactics:
+        assert getattr(tactic,'techniques')

--- a/tests/preattck/test_preattck_techniques.py
+++ b/tests/preattck/test_preattck_techniques.py
@@ -1,0 +1,26 @@
+import pytest 
+
+
+def test_preattck_techniques_have_tactics(attck_fixture):
+    """All Mitre PRE-ATT&CK Techniques should have tactics
+    
+    Args:
+        attck_fixture ([type]): our default Mitre PRE-ATT&CK JSON fixture
+    """
+    for technique in attck_fixture.preattack.techniques:
+        if technique.tactics:
+            assert getattr(technique,'tactics')
+
+def test_preattck_techniques_have_actors(attck_fixture):
+    """All Mitre PRE-ATT&CK Techniques should have tactics
+    
+    Args:
+        attck_fixture ([type]): our default Mitre PRE-ATT&CK JSON fixture
+    """
+    count = 0
+    for technique in attck_fixture.preattack.techniques:
+        if not hasattr(technique, 'actors'):
+            if technique.actors:
+                count += 1
+    if count >= 1:
+        assert True


### PR DESCRIPTION
Adding the ability to access MITRE PRE-ATT&CK Framework:

1. Added entrypoint for `preattack` off of the main `Attck` object similar to how `enterprise` works
2. Updated documentation
3. Added tests 