### PR TITLE
Minimum PyYAML requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests
 pendulum==2.0.5
 pyfiglet
-PyYaml
+PyYaml>=5.0
 Pillow
 fire==0.3.1


### PR DESCRIPTION
Old PyYAML versions (I tested with 3.12) don't support the FullLoader class. Using version 5 should be save. 
```
AttributeError: module 'yaml' has no attribute 'FullLoader'
```