### PR TITLE
Add deprecated attribute in enterprise and mobile

### DIFF
--- a/pyattck/enterprise/technique.py
+++ b/pyattck/enterprise/technique.py
@@ -96,6 +96,7 @@ class AttckTechnique(AttckObject):
         self.wiki = self._set_wiki(kwargs)
         self.contributors = self._set_list_items(kwargs, 'x_mitre_contributors')
         self.revoked = self._set_attribute(kwargs, 'revoked')
+        self.deprecated = self._set_attribute(kwargs, 'x_mitre_deprecated')
         self.subtechnique = self._set_attribute(kwargs, 'x_mitre_is_subtechnique')
         self.__subtechniques = []
 

--- a/pyattck/mobile/technique.py
+++ b/pyattck/mobile/technique.py
@@ -86,6 +86,7 @@ class MobileAttckTechnique(MobileAttckObject):
         self.external_reference = self._set_reference(kwargs)
         self.possible_detections = self._set_attribute(kwargs, 'x_mitre_detection')
         self.revoked = self._set_attribute(kwargs, 'revoked')
+        self.deprecated = self._set_attribute(kwargs, 'x_mitre_deprecated')
         self.wiki = self._set_wiki(kwargs)
         
         self.stix = self._set_attribute(kwargs, 'id')

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def parse_requirements(requirement_file):
 
 setup(
     name='pyattck',
-    version='2.1.2',
+    version='2.1.3',
     packages=find_packages(exclude=['tests*']),
     license='MIT',
     description='A Python package to interact with the Mitre ATT&CK Frameworks',


### PR DESCRIPTION
Add `deprecated` attribute from x_mitre_deprecated in enterprise and mobile (it was already present in preattack):

```
>>> from pyattck import Attck
>>> attack = Attck()
>>> [technique.id for technique in attack.enterprise.techniques if technique.deprecated]
['T1043', 'T1175', 'T1061', 'T1062', 'T1149', 'T1026', 'T1034', 'T1108', 'T1064', 'T1051', 'T1153']
```